### PR TITLE
Tweaks and Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,39 +132,48 @@
     function updateSideBoxContent(index) {
         if (index === 0) {
             sideBox.innerHTML = `
-			<img src="https://cdn.modrinth.com/data/FTeXqI9v/fe75695f6f2e085ac9fb56204de7f88b6d716e8d.png" alt="">
+			<img src="https://cdn.modrinth.com/data/FTeXqI9v/fe75695f6f2e085ac9fb56204de7f88b6d716e8d.png" alt="Create new age icon">
                 <h3 class="side-box-text">Create: New Age</h3>
                 <h4 class="side-box-dsc">Create: New Age is an addon for the Create mod that adds integration with electricity.</h4>
             `;
+            sideBox.onclick = function() {openLink("https://modrinth.com/mod/create-new-age")}
         } else if (index === 1) {
             // Add content for the second image
             sideBox.innerHTML = `
-			<img src="https://cdn.modrinth.com/data/ihpnEd80/1b6e859ac168a44ad383e36252ad6c563a245056.png" alt="">
+			<img src="https://cdn.modrinth.com/data/ihpnEd80/1b6e859ac168a44ad383e36252ad6c563a245056.png" alt="Create Cobblestone icon">
                 <h3 class="side-box-text">Create Cobblestone</h3>
                 <h4 class="side-box-dsc">Adds a block generating cobblestone using SU, stopping cobblestone generators from eating your frames.</h4>
             `;
+            sideBox.onclick = function() {openLink("https://modrinth.com/mod/create-cobblestone");}
         } else if (index === 2) {
             // Add content for the third image
             sideBox.innerHTML = `
-                <img src="https://cdn.modrinth.com/data/sMvUb4Rb/568feacea08ddad4bf91f5e5c396b76a7cba3e30.png" alt="">
+                <img src="https://cdn.modrinth.com/data/sMvUb4Rb/568feacea08ddad4bf91f5e5c396b76a7cba3e30.png" alt="Create Deco icon">
                 <h3 class="side-box-text">Create Deco</h3>
                 <h4 class="side-box-dsc">Industrial decoration themed around the aesthetics of the Create mod</h4>
             `;
+            sideBox.onclick = function() {openLink("https://modrinth.com/mod/create-deco");}
         } else if (index === 3) {
             // Add content for the third image
             sideBox.innerHTML = `
-                <img src="https://cdn.modrinth.com/data/gxoNIjg6/a67aa736ddbd20c45cca55d1dc5ef03c2caf841f.png" alt="">
+                <img src="https://cdn.modrinth.com/data/gxoNIjg6/a67aa736ddbd20c45cca55d1dc5ef03c2caf841f.png" alt="Create Track Map icon">
                 <h3 class="side-box-text">Create Track Map</h3>
                 <h4 class="side-box-dsc">A web-based track map of your world's Create train system, complete with signals, stations, and trains moving in real time.</h4>
             `;
+            sideBox.onclick = function() {("https://modrinth.com/mod/create-track-map");}
         } else if (index === 4) {
             // Add content for the third image
             sideBox.innerHTML = `
-                <img src="https://cdn.modrinth.com/data/j6Zt3N7W/7695e7967fd8386954b8b2f13e579b99c7839650.png" alt="">
+                <img src="https://cdn.modrinth.com/data/j6Zt3N7W/7695e7967fd8386954b8b2f13e579b99c7839650.png" alt="Create: Factory icon">
                 <h3 class="side-box-text">Create: Factory</h3>
                 <h4 class="side-box-dsc">🍬 A lot of new foods added to Create!</h4>
             `;
+            sideBox.onclick = function() {("https://modrinth.com/mod/create-factory")}
         }
+    }
+
+    function openLink(url) {
+        window.location.href = url;
     }
 
     // Call nextSlide() immediately to ensure content is loaded for the first image

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
 			<div class="home-slideshow-container">
 				<img src="static/banner1.webp" alt="" class="home-slideshow-image" id="home-slideshow-image">
 				<div class="side-box" id="side-box">(w)
-				</div>
-			</center>
+			</div>
+		</center>
 	</div>
 		
 	<br>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
         } else if (index === 2) {
             // Add content for the third image
             sideBox.innerHTML = `
-                <img src="https://cdn.modrinth.com/data/sMvUb4Rb/568feacea08ddad4bf91f5e5c396b76a7cba3e30.png" alt="Create Deco icon">
+                <img src="https://cdn.modrinth.com/data/sMvUb4Rb/b60e1330b10bd1d7b1f2c0b7337a25f73b0eb555_96.webp" alt="Create Deco icon">
                 <h3 class="side-box-text">Create Deco</h3>
                 <h4 class="side-box-dsc">Industrial decoration themed around the aesthetics of the Create mod</h4>
             `;

--- a/schematic-viewer.html
+++ b/schematic-viewer.html
@@ -29,7 +29,7 @@
 	<div id="dark-mode-toggle"></div>
 	<center>
 		<h1>Schematic Viewer</h1>
-		<input id="schematic-input" type="file" style="position: fixed; top: -100em">
+		<input id="schematic-input" type="file" accept=".nbt" style="position: fixed; top: -100em">
 		<label for="schematic-input">
 			<div class="drop-zone" ondrop="dropHandler(event);" ondragover="dragOverHandler(event)">
 				Drag and drop file here, or click to select one
@@ -54,6 +54,12 @@
 <script>
     const nbt = require('prismarine-nbt');
     const {Buffer} = require('buffer');
+
+    //When a file is selected, parse it
+    document.getElementById('schematic-input').addEventListener('change', function(e) {
+        parseFile(e.target.files[0]);
+    });
+
 
     const dropHandler = async (ev) => {
         console.log("File(s) dropped");

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,1 +1,20 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#B3CAE5","background_color":"#ffffff","display":"standalone"}
+{
+    "name":"Blueprint",
+    "short_name":"Blueprint",
+    "description":"The site with Create Mod addons",
+    "icons":[
+        {
+            "src":"/android-chrome-192x192.png",
+            "sizes":"192x192",
+            "type":"image/png"
+        },
+        {
+            "src":"/android-chrome-512x512.png",
+            "sizes":"512x512",
+            "type":"image/png"
+        }
+    ],
+    "theme_color":"#B3CAE5",
+    "background_color":"#ffffff",
+    "display":"standalone"
+}

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,7 +1,7 @@
 {
     "name":"Blueprint",
     "short_name":"Blueprint",
-    "description":"The site with Create Mod addons",
+    "description":"All in one Create Mod site",
     "icons":[
         {
             "src":"/android-chrome-192x192.png",

--- a/static/css/addons.css
+++ b/static/css/addons.css
@@ -6,7 +6,7 @@
     --container-background: #B3CAE5;
     --dark-container-background: #527caf;
 }
-body.dark-mode .search-input {
+body.dark-mode .search-input::placeholder {
     color: var(--dark-text-color);
 }
 body.dark-mode {
@@ -172,6 +172,10 @@ body.dark-mode .select-dropdown {
     width: 23vw;
     box-shadow: 3px 2px 5px rgb(0, 0, 0, 0.5);
     font-size: 1.5vw;
+}
+
+.search-input::placeholder {
+    color: var(--dark-text-color);
 }
 
 .search-button {

--- a/static/css/addons.css
+++ b/static/css/addons.css
@@ -195,6 +195,10 @@ body.dark-mode .select-dropdown {
     color: rgb(0, 0, 0, 0.6);
 }
 
+.search-button:hover {
+    filter: brightness(1.2);
+}
+
 .search-bar a {
     font-size: 1.5vw;
     background-color: var(--container-background);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -161,6 +161,7 @@ body.dark-mode .for-creators h1 {
 
 .side-box:hover {
     filter: brightness(1.05);
+    cursor: pointer;
 }
 
 .side-box img {

--- a/static/css/viewer.css
+++ b/static/css/viewer.css
@@ -20,6 +20,11 @@
     border-radius: 20px;
 }
 
+.drop-zone:hover {
+    cursor: pointer;
+    filter: brightness(1.05);
+}
+
 table {
     visibility: hidden;
     border-collapse: collapse;


### PR DESCRIPTION
This PR fix some bugs and add some feature to the Blueprint website

## Fix the search addon placeholder color
The color of the placeholder was gray on a blue background so it was difficult to read it
![image](https://github.com/user-attachments/assets/a2660669-380c-48cd-8ab3-14885009c3df)
![image](https://github.com/user-attachments/assets/a8a3f7fa-dd3e-4f7a-8417-85fbbbd72d21)

## Add alt to carousel images

## Clickable addons in the carousel
You can now click on the addons infos and be redirected to their modrinth page

## Fix of the schematic viewer
When clicked, the schematic viewer open a window to search for a file but do nothing when selecting a file. Not anymore.
The file format asked is now nbt so it's easier to look for a file

## CSS change
I made that some clickable object change the background light and the cursor to show that it's clickable

## Add more infos in the webmanifest
I added the `name` and `short_name` infos along with a `description`