### PR TITLE
Add wrap to addon versions

### DIFF
--- a/static/css/addons.css
+++ b/static/css/addons.css
@@ -117,9 +117,10 @@ body.dark-mode .select-dropdown {
     margin-top: 4px;
     margin-bottom: 4px;
     max-width: 100%;
-    overflow-y: hidden;
     padding-top: 4px;
     padding-bottom: 4px;
+    display: flex;
+    flex-wrap: wrap;
 }
 
 .addon-version {


### PR DESCRIPTION
This is a really minor things but I stumbled across it when I looked at your site (very nice btw)
I noticed that addons with many versions have them overflow using a horizontal scroll and though it might look better if they just wrap into the next line.

Here is a before/after for better understanding:

![before](https://github.com/user-attachments/assets/f7ea2004-6e1e-448b-b722-20b4e415f861)
![after](https://github.com/user-attachments/assets/b4992a40-d4e5-48b7-82ca-023276fc9f77)
