### PR TITLE
Fix infinite reload loop in Updater+ UX improvement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter, Routes, Route, Router, Navigate } from "react-router-dom";
-import { Suspense, lazy, useEffect } from "react";
+import { Suspense, lazy } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
 // Loading Overlays
 import LoadingOverlay from "./components/LoadingOverlays/LoadingOverlay";
@@ -30,11 +30,11 @@ import ProtectedRoute from "./components/ProtectedRoute";
 const Layout = lazy(() => import('./components/Layout'));
 
 // Translations
-import Translations from "./assets/translations.json";
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import XHR from "i18next-http-backend";
+import { initReactI18next } from "react-i18next";
+import Translations from "./assets/translations.json";
 
 // Updater 
 import Updater from "./components/Updater";
@@ -52,16 +52,15 @@ i18n
     },
   });
 
-const App = () => {
-  const isAuthenticated = () => {
-    return !!localStorage.getItem('token');
-  };
-
-  Updater();
-
-  return (
-    <BrowserRouter>
-      <Suspense fallback={<LoadingOverlay />}>
+  const App = () => {
+    const isAuthenticated = () => {
+      return !!localStorage.getItem('token');
+    };
+  
+    return (
+      <BrowserRouter>
+        <Suspense fallback={<LoadingOverlay />}>
+          <Updater />  {/* Proper JSX usage */}
         <Routes>
           <Route path="/" element={<Layout />}>
             <Route index element={<Home />} />


### PR DESCRIPTION
## Problem
The Updater component was triggering an infinite reload loop after one hour of uptime. This occurred because the component forced a page reload immediately after fetching updates, which would trigger another update check, creating an endless cycle.

## Changes
- Remove direct `window.location.reload()` call after fetching updates
- Add user-controlled reload mechanism with a confirmation prompt
- Properly integrate Updater component in App.tsx using JSX syntax
- Clean up imports in App.tsx for better organization
- Add conditional rendering for Updater UI elements

## New Update Flow
1. Fetches new data in the background
2. Successfully saves updates to localStorage
3. Prompts the user about available updates
4. Only reloads the page with user consent

## Testing
- [ ] Verify the app no longer enters an infinite reload loop after one hour
- [x] Confirm update prompts appear when new content is available
- [x] Check that localStorage values persist correctly between sessions
- [ ] Ensure Updater component only shows UI on its dedicated route