### PR TITLE
Improve SPA loading performance

### DIFF
--- a/src/components/utility/MinecraftIcon.tsx
+++ b/src/components/utility/MinecraftIcon.tsx
@@ -117,8 +117,6 @@ const MinecraftIcon = ({ name, size = 16, className }: MinecraftIconProps) => {
   const darkIcons = 'src/assets/icons/create_icons_dark.png';
   const { isDarkMode } = useThemeStore();
   
-  console.log('Theme state:', { isDarkMode, lightIcons, darkIcons });
-
   const [x, y] = iconPositions[name];
   
   return (

--- a/src/routes/addonRoutes.tsx
+++ b/src/routes/addonRoutes.tsx
@@ -2,7 +2,7 @@
 import { RouteObject } from 'react-router-dom';
 
 import AddonDetails from '@/components/Addons/AddonDetails';
-import RandomAddon from '@/components/Addons/RandomAddon';
+import RandomAddon from '@/components/RandomAddon';
 import Addons from '@/pages/Addons';
 
 export const addonRoutes: RouteObject[] = [

--- a/src/routes/addonRoutes.tsx
+++ b/src/routes/addonRoutes.tsx
@@ -1,10 +1,9 @@
 // src/routes/addonRoutes.tsx
-import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
 
-const Addons = lazy(() => import('@/pages/Addons'));
-const RandomAddon = lazy(() => import('@/components/RandomAddon'));
-const AddonDetails = lazy(() => import('@/components/Addons/AddonDetails'));
+import AddonDetails from '@/components/Addons/AddonDetails';
+import RandomAddon from '@/components/Addons/RandomAddon';
+import Addons from '@/pages/Addons';
 
 export const addonRoutes: RouteObject[] = [
   {

--- a/src/routes/authRoutes.tsx
+++ b/src/routes/authRoutes.tsx
@@ -1,11 +1,10 @@
 // src/routes/authRoutes.tsx
-import ProtectedRoute from '@/components/utility/ProtectedRoute';
-import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
 
-const AuthPage = lazy(() => import('@/pages/Auth'));
-const Profile = lazy(() => import('@/pages/Profile'));
-const Settings = lazy(() => import('@/pages/Settings'));
+import ProtectedRoute from '@/components/utility/ProtectedRoute';
+import AuthPage from '@/pages/Auth';
+import Profile from '@/pages/Profile';
+import Settings from '@/pages/Settings';
 
 export const authRoutes: RouteObject[] = [
   { path: 'user/:username', element: <Profile /> },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,4 @@
 // src/routes/index.tsx
-import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
 
 import { addonRoutes } from '@/routes/addonRoutes';
@@ -7,17 +6,16 @@ import { authRoutes } from '@/routes/authRoutes';
 import { schematicRoutes } from '@/routes/schematicRoutes';
 import { settingsRoutes } from '@/routes/settings';
 
-const Home = lazy(() => import('@/pages/Home'));
-const About = lazy(() => import('@/pages/About'));
-const NoPage = lazy(() => import('@/pages/NotFound'));
-const Design = lazy(() => import('@/pages/Design'));
-const Terms = lazy(() => import('@/pages/Terms'));
-const Privacy = lazy(() => import('@/pages/Privacy'));
+import About from '@/pages/About';
+import Design from '@/pages/Design';
+import Home from '@/pages/Home';
+import NotFound from '@/pages/NotFound';
+import Privacy from '@/pages/Privacy';
+import Terms from '@/pages/Terms';
 
-const BaseLayout = lazy(() => import('@/layouts/BaseLayout'));
-const SidebarLayout = lazy(() => import('@/layouts/SidebarLayout'));
-const SchematicLayout = lazy(() => import('@/layouts/3DViewerLayout'));
-
+import SchematicLayout from '@/layouts/3DViewerLayout';
+import BaseLayout from '@/layouts/BaseLayout';
+import SidebarLayout from '@/layouts/SidebarLayout';
 
 export const routes: RouteObject[] = [
   {
@@ -30,7 +28,7 @@ export const routes: RouteObject[] = [
       { path: 'privacy', element: <Privacy /> },
       ...authRoutes,
       ...settingsRoutes,
-      { path: '*', element: <NoPage /> },
+      { path: '*', element: <NotFound /> },
     ]
   },
   {


### PR DESCRIPTION
This pull request includes changes to the codebase that focus on removing unnecessary lazy loading of components and cleaning up debug statements. The most important change is to remove lazy loading of pages to enable proper single page application routing for snappier page load time.

### Codebase simplification:

* [`src/routes/addonRoutes.tsx`](diffhunk://#diff-fb1e6e818ef0fda7f05e561dac6d521bc4fa8d44b370ca7b9d871fee38a7bf3aL2-R6): Removed `lazy` loading for `Addons`, `RandomAddon`, and `AddonDetails` components and imported them directly.
* [`src/routes/authRoutes.tsx`](diffhunk://#diff-f9345829700e6d21f450184a4941f97b81c1a6233d21bb85c4362667989d64c8L2-R7): Removed `lazy` loading for `AuthPage`, `Profile`, and `Settings` components and imported them directly.
* [`src/routes/index.tsx`](diffhunk://#diff-3d4d2177c21702138c6c0473b20d38d819dec2249dd99cbf1d00fde1f6ac5115L2-R18): Removed `lazy` loading for multiple components including `Home`, `About`, `NoPage`, `Design`, `Terms`, `Privacy`, `BaseLayout`, `SidebarLayout`, and `SchematicLayout`, and imported them directly.

### Cleanup:

* [`src/components/utility/MinecraftIcon.tsx`](diffhunk://#diff-d2c1e7abeb2b1bef0fcb4f9ef8d43d0fc23424872669133a0adb62d80eae7237L120-L121): Removed a console log statement that was used for debugging the theme state.
* [`src/routes/index.tsx`](diffhunk://#diff-3d4d2177c21702138c6c0473b20d38d819dec2249dd99cbf1d00fde1f6ac5115L33-R31): Updated the wildcard route to use `NotFound` instead of `NoPage`.