### PR TITLE
Fix import path for RandomAddon component in addonRoutes

### DIFF
--- a/src/routes/addonRoutes.tsx
+++ b/src/routes/addonRoutes.tsx
@@ -2,7 +2,7 @@
 import { RouteObject } from 'react-router-dom';
 
 import AddonDetails from '@/components/Addons/AddonDetails';
-import RandomAddon from '@/components/RandomAddon';
+import RandomAddon from '@/components/Addons/RandomAddon';
 import Addons from '@/pages/Addons';
 
 export const addonRoutes: RouteObject[] = [


### PR DESCRIPTION
This pull request includes a minor change to the `src/routes/addonRoutes.tsx` file. The change corrects the import path for the `RandomAddon` component to ensure it is properly imported from the `Addons` directory.

* [`src/routes/addonRoutes.tsx`](diffhunk://#diff-fb1e6e818ef0fda7f05e561dac6d521bc4fa8d44b370ca7b9d871fee38a7bf3aL5-R5): Corrected the import path for `RandomAddon` to `@/components/Addons/RandomAddon`.