### PR TITLE
Add Prettier configuration and ignore file for code formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,39 @@
+# Dependencies
+node_modules
+yarn.lock
+package-lock.json
+
+# Build outputs
+dist
+build
+.next
+public/build
+
+# Generated files
+coverage
+.nyc_output
+.vscode
+.idea
+.DS_Store
+
+# Cache
+.cache
+.eslintcache
+.npm
+.parcel-cache
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Project specific
+tailwind.config.js
+components.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": true,
+  "arrowParens": "always",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "lf",
+  "quoteProps": "as-needed",
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,8 @@
         "postcss": "^8.5.1",
         "postcss-cli": "^11.0.0",
         "postcss-import": "^16.1.0",
+        "prettier": "^3.5.2",
+        "prettier-plugin-tailwindcss": "^0.6.11",
         "react-router-dom": "^6.23.0",
         "rollup-plugin-visualizer": "^5.14.0",
         "tailwindcss": "^4.0.7",
@@ -21264,7 +21266,6 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -21274,7 +21275,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21291,7 +21291,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21303,13 +21302,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21326,7 +21323,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21341,13 +21337,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "6.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21394,7 +21388,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21413,7 +21406,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21425,7 +21417,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21437,7 +21428,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "4.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21456,7 +21446,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21472,7 +21461,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21487,7 +21475,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21502,7 +21489,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21511,7 +21497,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21520,7 +21505,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21538,7 +21522,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21550,7 +21533,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21562,7 +21544,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21578,7 +21559,6 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -21588,7 +21568,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -21597,7 +21576,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21610,7 +21588,6 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21619,7 +21596,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21628,7 +21604,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21641,7 +21616,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21650,7 +21624,6 @@
     },
     "node_modules/npm/node_modules/abort-controller": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21662,7 +21635,6 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21674,7 +21646,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21688,7 +21659,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21701,7 +21671,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21710,7 +21679,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21725,19 +21693,16 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21750,13 +21715,11 @@
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21776,7 +21739,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21791,7 +21753,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21800,7 +21761,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21809,7 +21769,6 @@
     },
     "node_modules/npm/node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21833,7 +21792,6 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21842,7 +21800,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "17.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21865,7 +21822,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21877,7 +21833,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21886,7 +21841,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "3.8.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21901,7 +21855,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -21913,7 +21866,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21922,7 +21874,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21935,7 +21886,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21950,7 +21900,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21959,7 +21908,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21968,7 +21916,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21980,13 +21927,11 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -21995,7 +21940,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22008,25 +21952,21 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22040,7 +21980,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22055,7 +21994,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -22067,7 +22005,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22084,13 +22021,11 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22102,13 +22037,11 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22117,7 +22050,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -22126,19 +22058,16 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -22148,7 +22077,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22157,13 +22085,11 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/event-target-shim": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22172,7 +22098,6 @@
     },
     "node_modules/npm/node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22181,13 +22106,11 @@
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22196,7 +22119,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22212,7 +22134,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22224,19 +22145,16 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22255,7 +22173,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22277,13 +22194,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22295,13 +22210,11 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "6.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22313,13 +22226,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22333,7 +22244,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22346,7 +22256,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22355,7 +22264,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -22368,7 +22276,6 @@
     },
     "node_modules/npm/node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22388,7 +22295,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "6.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22400,7 +22306,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22409,7 +22314,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22418,7 +22322,6 @@
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22428,13 +22331,11 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22443,7 +22344,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22461,13 +22361,11 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22476,7 +22374,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22488,7 +22385,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.12.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22500,7 +22396,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22509,19 +22404,16 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -22539,7 +22431,6 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22548,7 +22439,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -22557,7 +22447,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -22566,19 +22455,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22591,7 +22477,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "5.0.19",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22611,7 +22496,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "6.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22633,7 +22517,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "4.0.19",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22645,7 +22528,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "9.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22658,7 +22540,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "5.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22671,7 +22552,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "5.0.19",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22686,7 +22566,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "7.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22705,7 +22584,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22717,7 +22595,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "5.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22730,7 +22607,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22746,7 +22622,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "7.18.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22755,7 +22630,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "11.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22781,7 +22655,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22796,7 +22669,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22805,7 +22677,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22817,7 +22688,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22829,7 +22699,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22846,7 +22715,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22858,7 +22726,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22870,7 +22737,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22880,7 +22746,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22892,7 +22757,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22904,7 +22768,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22916,7 +22779,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22928,7 +22790,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22940,7 +22801,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22953,7 +22813,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22965,7 +22824,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -22977,13 +22835,11 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22992,7 +22848,6 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23001,7 +22856,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23026,13 +22880,11 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23045,7 +22897,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23055,7 +22906,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23074,7 +22924,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23094,7 +22943,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23106,7 +22954,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23121,7 +22968,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23136,7 +22982,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
       "version": "3.6.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23150,13 +22995,11 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23171,7 +23014,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "7.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23186,7 +23028,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -23201,7 +23042,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23210,7 +23050,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23222,7 +23061,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "6.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -23234,7 +23072,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23243,7 +23080,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "10.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23258,7 +23094,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "7.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23270,7 +23105,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "8.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23285,7 +23119,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23298,7 +23131,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "14.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23316,7 +23148,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -23325,7 +23156,6 @@
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23340,7 +23170,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23349,7 +23178,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23364,7 +23192,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "15.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23396,7 +23223,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23410,7 +23236,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23419,7 +23244,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23428,7 +23252,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.9.2",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -23444,7 +23267,6 @@
     },
     "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
       "version": "9.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23453,7 +23275,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23466,7 +23287,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23475,7 +23295,6 @@
     },
     "node_modules/npm/node_modules/process": {
       "version": "0.11.10",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23484,7 +23303,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -23493,7 +23311,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -23502,13 +23319,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23521,7 +23336,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23533,7 +23347,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -23541,7 +23354,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23553,7 +23365,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23562,7 +23373,6 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "6.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23577,7 +23387,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23590,7 +23399,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "4.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23605,7 +23413,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23614,7 +23421,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23629,7 +23435,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23639,7 +23444,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23659,7 +23463,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23671,7 +23474,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23691,14 +23493,12 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23713,7 +23513,6 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23725,13 +23524,11 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23743,7 +23540,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23752,7 +23548,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23764,7 +23559,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "1.7.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23781,7 +23575,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23791,7 +23584,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23805,7 +23597,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23819,7 +23610,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23829,13 +23619,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23845,13 +23633,11 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.13",
-      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "10.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23863,7 +23649,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23872,7 +23657,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23887,7 +23671,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23901,7 +23684,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23914,7 +23696,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23926,7 +23707,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23938,7 +23718,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.15",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23955,7 +23734,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23967,7 +23745,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23979,19 +23756,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -24000,7 +23774,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "1.1.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24014,7 +23787,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24026,7 +23798,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24038,13 +23809,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24054,7 +23823,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24066,13 +23834,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24081,7 +23847,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24096,7 +23861,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24105,7 +23869,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24123,7 +23886,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24140,7 +23902,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -24152,7 +23913,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -24164,13 +23924,11 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24187,7 +23945,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24202,13 +23959,11 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24221,7 +23976,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -25466,6 +25220,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
+      "integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier --write .",
     "preview": "vite preview",
     "update": "git pull && npm install",
     "docker-build": "docker build --no-cache -t blueprint-app ."
@@ -94,6 +95,8 @@
     "postcss": "^8.5.1",
     "postcss-cli": "^11.0.0",
     "postcss-import": "^16.1.0",
+    "prettier": "^3.5.2",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "react-router-dom": "^6.23.0",
     "rollup-plugin-visualizer": "^5.14.0",
     "tailwindcss": "^4.0.7",


### PR DESCRIPTION
# Add Prettier configuration for consistent code formatting

## Overview
This PR adds Prettier to the project along with a standardized configuration to ensure consistent code formatting across the entire Blueprint codebase. This will help maintain code quality and reduce merge conflicts caused by formatting differences.

## Changes
- Add `.prettierrc` with configuration tailored for our React/TypeScript project
- Add `.prettierignore` to exclude appropriate files from formatting
- Add `format` script to package.json to easily run formatter
- Install Prettier and Tailwind plugin as dev dependencies

## Configuration Details
The Prettier configuration includes:
- Single quotes for strings and JSX
- Semicolons at the end of statements
- 100 character line width
- 2-space indentation
- Trailing commas in objects and arrays
- LF line endings
- Special integration with Tailwind CSS

## How to Use
Developers can now run `npm run format` to format the entire codebase or configure their editors to use Prettier on save with this configuration.