### PR TITLE
Feat: Add db prop to TagSelector and use different collections

### DIFF
--- a/src/components/features/admin/blog/components/AdminBlogEditor.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogEditor.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Input } from '@/components/ui/input.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { Card, CardContent } from '@/components/ui/card.tsx';
-import { BlogType } from '@/types';
+import {BlogType, Tag} from '@/types';
 import { useLoggedUser } from '@/api/context/loggedUser/loggedUserContext.tsx';
 import ImageUploader from '@/components/utility/ImageUploader.tsx';
 import MarkdownEditor from '@/components/utility/MarkdownEditor.tsx';
@@ -112,8 +112,10 @@ const AdminBlogEditor = () => {
               />
               <h3>Tags</h3>
               <TagSelector
-                value={blogState?.tags || []}
-                onChange={(value) =>
+                value={blogState?.tags || []
+              }
+                db={"blog"}
+                onChange={(value: Tag[]) =>
                   setBlogState((prev) => (prev ? { ...prev, tags: value ?? undefined } : null))
                 }
               />

--- a/src/components/utility/blog/TagSelector.tsx
+++ b/src/components/utility/blog/TagSelector.tsx
@@ -15,14 +15,17 @@ import { databases, ID } from '@/config/appwrite.ts';
 import { Models, Query } from 'appwrite';
 
 const DATABASE_ID = '67b1dc430020b4fb23e3';
-const COLLECTION_ID = '67b2326100053d0e304f';
+const BLOG_COLLECTION_ID= '67b2326100053d0e304f';
+const SCHEMATICS_COLLECTION_ID= '67bf59d30021b5c117f5';
+let COLLECTION_ID = '67b2326100053d0e304f';
 
 interface TagSelectorProps {
   value?: Tag[];
+  db: 'blog' | 'schematics'
   onChange?: (selectedTags: Tag[]) => void;
 }
 
-export default function TagSelector({ value, onChange }: TagSelectorProps) {
+export default function TagSelector({ value,db, onChange }: TagSelectorProps) {
   const [tags, setTags] = useState<Tag[]>([]);
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [newTag, setNewTag] = useState('');
@@ -32,7 +35,15 @@ export default function TagSelector({ value, onChange }: TagSelectorProps) {
     if (value) {
       setSelectedTags(value);
     }
-  }, [value]);
+    if(db){
+      if(db === 'blog'){
+        COLLECTION_ID = BLOG_COLLECTION_ID
+      }
+      if(db === 'schematics'){
+        COLLECTION_ID = SCHEMATICS_COLLECTION_ID
+      }
+    }
+  }, [value, db]);
 
   async function fetchTags() {
     try {


### PR DESCRIPTION

This commit introduces a `db` prop to the `TagSelector` component, allowing it to fetch tags from different collections based on the specified database.

- Add `db` prop to `TagSelector` component.
- Use different collection IDs based on the `db` prop.
- Pass `db` prop to `TagSelector` in `AdminBlogEditor`.