### PR TITLE
feature/blog-update

### DIFF
--- a/src/api/endpoints/useAddons.tsx
+++ b/src/api/endpoints/useAddons.tsx
@@ -2,7 +2,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/api';
 import { databases, ID } from '@/config/appwrite.ts';
 import { Query } from 'appwrite';
-import { Addon } from '@/schemas/addon.schema.tsx';
+import { Addon } from '@/types';
+
 
 const DATABASE_ID = '67b1dc430020b4fb23e3';
 const COLLECTION_ID = '67b1dc4b000762a0ccc6';

--- a/src/api/endpoints/useBlogs.tsx
+++ b/src/api/endpoints/useBlogs.tsx
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/api';
 import { databases, ID } from '@/config/appwrite.ts';
 import { Query } from 'appwrite';
-import {Blog} from "@/schemas/blog.schema.tsx";
+import { Blog } from '@/types';
 
 // Constantes pour votre base de données
 const DATABASE_ID = '67b1dc430020b4fb23e3';

--- a/src/api/endpoints/useBlogs.tsx
+++ b/src/api/endpoints/useBlogs.tsx
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Blog } from '@/types';
 import { toast } from '@/api';
 import { databases, ID } from '@/config/appwrite.ts';
 import { Query } from 'appwrite';
+import {Blog} from "@/schemas/blog.schema.tsx";
 
 // Constantes pour votre base de données
 const DATABASE_ID = '67b1dc430020b4fb23e3';
@@ -51,11 +51,12 @@ export const useFetchBlog = (blogId?: string) => {
       const response = await databases.getDocument(DATABASE_ID, COLLECTION_ID, blogId);
       const blogData: Blog = {
         $id: response.$id,
+        $createdAt: response.$createdAt || '',
+        $updatedAt: response.$updatedAt || '',
         title: response.title || '',
         content: response.content || '',
         slug: response.slug || '',
         authors: response.author || '',
-        created_at: response.$createdAt || '',
         img_url: response.img_url || '',
         status: response.status || '',
         links: response.links ? JSON.parse(response.links as string) : [],
@@ -132,11 +133,12 @@ export const useFetchBlogs = (query: string = '', tagId: string = 'all', page: n
 
         const blogs: Blog[] = response.documents.map((doc) => ({
           $id: doc.$id,
+          $createdAt: doc.$createdAt || '',
+          $updatedAt: doc.$updatedAt || '',
           title: doc.title || '',
           content: doc.content || '',
           slug: doc.slug || '',
           authors: doc.authors || [],
-          created_at: doc.$createdAt || '',
           img_url: doc.img_url || '',
           status: doc.status || '',
           links: doc.links ? JSON.parse(doc.links as string) : [],

--- a/src/api/endpoints/useSchematics.tsx
+++ b/src/api/endpoints/useSchematics.tsx
@@ -14,7 +14,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/api';
 import { databases, ID } from '@/config/appwrite.ts';
 import { Query } from 'appwrite';
-import { Schematic } from '@/schemas/schematic.schema';
+import {Schematic} from "@/types";
 
 // Appwrite database configuration
 const DATABASE_ID = '67b1dc430020b4fb23e3';

--- a/src/api/endpoints/useSearchAddons.tsx
+++ b/src/api/endpoints/useSearchAddons.tsx
@@ -1,7 +1,7 @@
 // /src/api/endpoints/useSearchAddons.tsx
 import { useQuery } from '@tanstack/react-query';
 import searchClient from '@/config/meilisearch.ts';
-import { Addon } from '@/schemas/addon.schema.tsx';
+import { Addon } from '@/types';
 import { useState, useEffect } from 'react';
 
 export const useSearchAddons = (

--- a/src/api/endpoints/useSearchBlogs.tsx
+++ b/src/api/endpoints/useSearchBlogs.tsx
@@ -1,6 +1,6 @@
 import searchClient from "@/config/meilisearch";
 import { useQuery } from "@tanstack/react-query";
-import {Blog, SearchBlogProps, SearchBlogResultSchema} from "@/schemas/blog.schema.tsx";
+import {Blog, SearchBlogProps, SearchBlogResultSchema} from "@/types";
 
 
 export const useSearchBlogs = ({

--- a/src/api/endpoints/useSearchBlogs.tsx
+++ b/src/api/endpoints/useSearchBlogs.tsx
@@ -1,0 +1,89 @@
+import searchClient from "@/config/meilisearch";
+import { useQuery } from "@tanstack/react-query";
+import {Blog, SearchBlogProps, SearchBlogResultSchema} from "@/schemas/blog.schema.tsx";
+
+
+export const useSearchBlogs = ({
+                                        query = '',
+                                        page = 1,
+                                        tags = ['All'] ,
+                                        id = 'all',
+                                    }: SearchBlogProps): SearchBlogResultSchema => {
+    if(query === ''){
+        query = '*'
+    }
+    // Define filter logic for category, version, and loaders
+    const filter = (): string => {
+        const filters: string[] = [];
+        const addFilter = (field: string, value: string) => {
+            if (value && value !== 'all' && value !== 'All') {
+                const formattedValue = value.includes(' ') ? `"${value}"` : value;
+                filters.push(`${field} = ${formattedValue}`);
+            }
+        };
+
+        addFilter('$id', id);
+        addFilter('tags', tags[0]);
+
+        return filters.length > 0 ? filters.join(' AND ') : '';
+    };
+    const queryResult = useQuery({
+        queryKey: ['searchBlogs', query, page, tags, id],
+        queryFn: async () => {
+            const index = searchClient.index('blogs');
+            const result = await index.search(query, {
+                limit: 20,
+                offset: (page - 1) * 20,
+                filter: filter(),
+            });
+            const blogList = result.hits as Blog[]
+            console.log(filter())
+
+            // Transform `Hits<SchematicsAnswer>` into `Schematic[]`
+            const blogs: Blog[] = blogList.map((hit) => ({
+                $id: hit.$id, // Ensure this matches the property returned by Meilisearch
+                $createdAt: hit.$createdAt,
+                $updatedAt: hit.$updatedAt,
+                title: hit.title,
+                content: hit.content,
+                slug: hit.slug,
+                img_url: hit.img_url,
+                status: hit.status,
+                links: hit.links,
+                tags: hit.tags,
+                likes: hit.likes,
+                authors_uuid: hit.authors_uuid,
+                authors: hit.authors,
+            }));
+
+            return {
+                data: blogs,
+                totalHits: result.estimatedTotalHits ?? 0,
+            };
+        },
+        staleTime: 1000 * 60 * 5,
+        enabled: !!query,
+    });
+
+    const { data, isLoading, isError, error, isFetching } = queryResult;
+
+    // `data` is now an array of Schematic objects
+    const blogs = data?.data ?? [];
+
+    const totalHits = data?.totalHits ?? 0;
+    const hasNextPage = (page - 1) * 20 + blogs.length < totalHits;
+    const hasPreviousPage = page > 1;
+
+    return {
+        ...queryResult,
+        data: blogs,
+        hasNextPage,
+        hasPreviousPage,
+        totalHits,
+        page,
+        isLoading,
+        isError,
+        error,
+        isFetching
+    }
+};

--- a/src/api/endpoints/useSearchSchematics.tsx
+++ b/src/api/endpoints/useSearchSchematics.tsx
@@ -1,8 +1,7 @@
 import searchClient from "@/config/meilisearch";
 
 import { useQuery } from "@tanstack/react-query";
-import {Schematic, SearchSchematicsResult} from "@/schemas/schematic.schema.tsx";
-import {SearchSchematicsProps} from "@/types";
+import {Schematic, SearchSchematicsProps, SearchSchematicsResult} from "@/types";
 
 export const useSearchSchematics = ({
   query = '',

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -7,7 +7,7 @@ export {
   useIsDesktop,
   useCurrentBreakpoint,
 } from './endpoints/useBreakpoints.tsx';
-export { useToast, toast } from './endpoints/useToast.tsx';
+export { useToast, toast } from '../hooks/useToast.tsx';
 export { useSystemThemeSync } from './endpoints/useSystemThemeSync.tsx';
 export {
   useDeleteAddon,

--- a/src/components/features/addons/AddonList.tsx
+++ b/src/components/features/addons/AddonList.tsx
@@ -7,7 +7,7 @@ import { FiltersContainer } from '@/components/layout/FiltersContainer';
 import { ItemGrid } from '@/components/layout/ItemGrid';
 import AddonCard from '@/components/features/addons/addon-card/AddonCard.tsx';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'; // Import the hook
-import { Addon } from '@/schemas/addon.schema.tsx';
+import { Addon } from '@/types';
 
 const AddonsList = () => {
   const [query, setQuery] = useState('');

--- a/src/components/features/addons/addon-card/AddonCard.tsx
+++ b/src/components/features/addons/addon-card/AddonCard.tsx
@@ -9,7 +9,7 @@ import { VersionBadges } from './VersionBadges';
 import { AddonStats } from './AddonStats';
 import { ExternalLinks } from './ExternalLinks';
 import { useNavigate } from 'react-router-dom';
-import { Addon } from '@/schemas/addon.schema.tsx';
+import { Addon } from '@/types';
 
 interface AddonListItemProps {
   addon: Addon;

--- a/src/components/features/addons/addon-card/ModLoaders.tsx
+++ b/src/components/features/addons/addon-card/ModLoaders.tsx
@@ -8,7 +8,7 @@ import DevinsBadges from '@/components/utility/DevinsBadges.tsx';
 import { Badge } from '@/components/ui/badge.tsx';
 
 import { useMemo } from 'react';
-import { Addon } from '@/schemas/addon.schema.tsx';
+import { Addon } from '@/types';
 
 const MODLOADERS = ['forge', 'fabric', 'neoforge', 'quilt'];
 

--- a/src/components/features/admin/addons/AdminAddonsTable.tsx
+++ b/src/components/features/admin/addons/AdminAddonsTable.tsx
@@ -7,7 +7,7 @@ import { DataTable } from '@/components/tables/addonChecks/data-table';
 import { Button } from '@/components/ui/button.tsx';
 import { useFetchAddons, useSaveAddon } from '@/api/endpoints/useAddons.tsx';
 import { toast } from '@/api';
-import { Addon } from "@/schemas/addon.schema.tsx";
+import { Addon } from "@/types";
 import { Switch } from '@/components/ui/switch';
 
 const AdminAddonsTable = () => {

--- a/src/components/features/admin/blog/components/AdminBlogEditor.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogEditor.tsx
@@ -37,7 +37,6 @@ const AdminBlogEditor = () => {
         likes: 0,
         authors_uuid: [LoggedUser.user?.$id || ''],
         authors: [LoggedUser.user?.name || ''],
-        created_at: new Date().toISOString(),
       });
     }
   }, [id, blog, isNew, LoggedUser]);

--- a/src/components/features/admin/blog/components/AdminBlogEditor.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogEditor.tsx
@@ -24,7 +24,7 @@ const AdminBlogEditor = () => {
     if (!LoggedUser) return;
 
     if (id && !isNew && blog) {
-      console.log(blog)
+      console.log(blog);
       setBlogState(blog);
     } else {
       setBlogState({
@@ -40,7 +40,7 @@ const AdminBlogEditor = () => {
         created_at: new Date().toISOString(),
       });
     }
-  }, [blog, isNew, LoggedUser]);
+  }, [id, blog, isNew, LoggedUser]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -79,68 +79,74 @@ const AdminBlogEditor = () => {
   if (isLoading) return <div>Loading...</div>;
 
   return (
-    <>
-      <div className='mt-4 text-center'>
-        <h1>Blog Article Editor</h1>
-      </div>
-      <Card className='mx-auto w-full p-4 py-4'>
-        <CardContent className='w-full'>
-          <div className='flex flex-row gap-4 py-4'>
-            <div className='w-1/3'>
-              <ImageUploader
-                value={blogState?.img_url}
-                onChange={(base64) =>
-                  setBlogState((prev) => (prev ? { ...prev, img_url: base64 ?? undefined } : null))
-                }
-              />
-            </div>
-            <div className='w-full justify-end'>
-              <h3>Title</h3>
-              <Input
-                name='title'
-                value={blogState?.title || ''}
-                onChange={handleChange}
-                placeholder='Title'
-                className='mb-2 w-full'
-              />
-              <h3>Slug</h3>
-              <Input
-                name='slug'
-                value={blogState?.slug || ''}
-                onChange={handleChange}
-                placeholder='Slug'
-                className='mb-2 w-full'
-              />
-              <h3>Tags</h3>
-              <TagSelector
-                value={blogState?.tags || []
-              }
-                db={"blog"}
-                onChange={(value: Tag[]) =>
-                  setBlogState((prev) => (prev ? { ...prev, tags: value ?? undefined } : null))
-                }
-              />
-            </div>
-          </div>
-          <div className='w-full'>
-            <h3>Content</h3>
-            <MarkdownEditor
-                value={blogState?.content || ''}
-                onChange={(value) =>
-                  setBlogState((prev) => (prev ? { ...prev, content: value ?? undefined } : null))
-                     }
-            />
-          </div>
+      <Card className="mx-auto w-full p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-semibold">Blog Article Editor</h1>
           <Button
-            className='float-end py-4'
-            onClick={handleSave}
-            disabled={saveBlogMutation.isPending}
+              onClick={handleSave}
+              disabled={saveBlogMutation.isPending}
+              className="ml-auto"
           >
             {saveBlogMutation.isPending ? 'Saving...' : 'Save'}
           </Button>
-        </CardContent>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {/* Sidebar (Metadata) */}
+          <div className="md:col-span-1">
+            <CardContent className="space-y-4">
+              <ImageUploader
+                  value={blogState?.img_url}
+                  onChange={(base64) =>
+                      setBlogState((prev) => (prev ? { ...prev, img_url: base64 ?? undefined } : null))
+                  }
+              />
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Title</h3>
+                <Input
+                    name="title"
+                    value={blogState?.title || ''}
+                    onChange={handleChange}
+                    placeholder="Title"
+                    className="w-full"
+                />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Slug</h3>
+                <Input
+                    name="slug"
+                    value={blogState?.slug || ''}
+                    onChange={handleChange}
+                    placeholder="Slug"
+                    className="w-full"
+                />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Tags</h3>
+                <TagSelector
+                    value={blogState?.tags || []}
+                    db="blog"
+                    onChange={(value: Tag[]) =>
+                        setBlogState((prev) => (prev ? { ...prev, tags: value ?? undefined } : null))
+                    }
+                />
+              </div>
+            </CardContent>
+          </div>
+
+          {/* Main Content (Markdown Editor) */}
+          <div className="md:col-span-3">
+            <div className="h-[calc(100vh-200px)] overflow-auto">
+              <MarkdownEditor
+                  value={blog?.content ?? ''}
+                  onChange={(value) =>
+                      setBlogState((prev) => (prev ? { ...prev, content: value ?? undefined } : null))
+                  }
+              />
+            </div>
+          </div>
+        </div>
       </Card>
-    </>
   );
 };
 

--- a/src/components/features/admin/blog/components/AdminBlogEditor.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogEditor.tsx
@@ -24,6 +24,7 @@ const AdminBlogEditor = () => {
     if (!LoggedUser) return;
 
     if (id && !isNew && blog) {
+      console.log(blog)
       setBlogState(blog);
     } else {
       setBlogState({
@@ -124,10 +125,10 @@ const AdminBlogEditor = () => {
           <div className='w-full'>
             <h3>Content</h3>
             <MarkdownEditor
-              value={blogState?.content || ''}
-              onChange={(value) =>
-                setBlogState((prev) => (prev ? { ...prev, content: value ?? undefined } : null))
-              }
+                value={blogState?.content || ''}
+                onChange={(value) =>
+                  setBlogState((prev) => (prev ? { ...prev, content: value ?? undefined } : null))
+                     }
             />
           </div>
           <Button

--- a/src/components/features/admin/blog/components/AdminBlogList.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogList.tsx
@@ -73,7 +73,7 @@ const AdminBlogList = () => {
       ),
     },
     {
-      accessorKey: 'created_at',
+      accessorKey: '$createdAt',
       header: ({ column }) => (
         <Button
           variant='ghost'

--- a/src/components/features/admin/blog/components/AdminBlogList.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogList.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import { useDeleteBlog, useFetchBlogs, useSaveBlog } from '@/api';
-import { Blog } from '@/types';
+import {Blog} from "@/schemas/blog.schema.tsx";
 
 const AdminBlogList = () => {
   const { data: blogs, isLoading, error } = useFetchBlogs();
@@ -152,7 +152,7 @@ const AdminBlogList = () => {
   if (isLoading) return <p>Loading blogs...</p>;
   if (error) return <p>Error loading blogs: {(error as Error).message}</p>;
 
-  return <AdminBlogTable columns={columns} data={blogs || []} />;
+  return <AdminBlogTable columns={columns} data={blogs?.data || []} />;
 };
 
 export default AdminBlogList;

--- a/src/components/features/admin/blog/components/AdminBlogList.tsx
+++ b/src/components/features/admin/blog/components/AdminBlogList.tsx
@@ -12,7 +12,8 @@ import {
 import { Button } from '@/components/ui/button.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import { useDeleteBlog, useFetchBlogs, useSaveBlog } from '@/api';
-import {Blog} from "@/schemas/blog.schema.tsx";
+import {Blog} from "@/types";
+
 
 const AdminBlogList = () => {
   const { data: blogs, isLoading, error } = useFetchBlogs();

--- a/src/components/features/blog/BlogCard.tsx
+++ b/src/components/features/blog/BlogCard.tsx
@@ -8,7 +8,8 @@ import {
 } from '@/components/ui/card.tsx';
 import MarkdownDisplay from '@/components/utility/MarkdownDisplay.tsx';
 import BlogTagsDisplay from '@/components/utility/blog/BlogTagsDisplay.tsx';
-import { Blog } from '@/schemas/blog.schema.tsx';
+import {Blog} from "@/types";
+
 
 interface BlogCardProps {
   blog: Blog;

--- a/src/components/features/schematics/SchematicCard.tsx
+++ b/src/components/features/schematics/SchematicCard.tsx
@@ -12,7 +12,7 @@ import {
 import { Badge } from '@/components/ui/badge.tsx';
 import ModLoaderDisplay from '@/components/common/ModLoaderDisplay.tsx';
 import { useIncrementDownloads } from '@/api/endpoints/useSchematics.tsx';
-import {Schematic} from "@/schemas/schematic.schema.tsx";
+import {Schematic} from "@/types";
 
 interface SchematicCardProps {
   schematic: Schematic;

--- a/src/components/features/schematics/SchematicCard.tsx
+++ b/src/components/features/schematics/SchematicCard.tsx
@@ -11,8 +11,8 @@ import {
 } from '@/components/ui/card.tsx';
 import { Badge } from '@/components/ui/badge.tsx';
 import ModLoaderDisplay from '@/components/common/ModLoaderDisplay.tsx';
-import { Schematic } from '@/types';
 import { useIncrementDownloads } from '@/api/endpoints/useSchematics.tsx';
+import {Schematic} from "@/schemas/schematic.schema.tsx";
 
 interface SchematicCardProps {
   schematic: Schematic;

--- a/src/components/features/schematics/SchematicsList.tsx
+++ b/src/components/features/schematics/SchematicsList.tsx
@@ -13,7 +13,7 @@ import { ItemGrid } from '@/components/layout/ItemGrid';
 import { useSchematicFilters } from '@/hooks/useSchematicFilters';
 import { Link } from 'react-router-dom';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import {Schematic} from "@/schemas/schematic.schema.tsx";
+import {Schematic} from "@/types";
 
 function SchematicsList() {
   const navigate = useNavigate();

--- a/src/components/features/schematics/SchematicsList.tsx
+++ b/src/components/features/schematics/SchematicsList.tsx
@@ -13,7 +13,7 @@ import { ItemGrid } from '@/components/layout/ItemGrid';
 import { useSchematicFilters } from '@/hooks/useSchematicFilters';
 import { Link } from 'react-router-dom';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { Schematic } from '@/types';
+import {Schematic} from "@/schemas/schematic.schema.tsx";
 
 function SchematicsList() {
   const navigate = useNavigate();

--- a/src/components/features/schematics/UserSchematicList.tsx
+++ b/src/components/features/schematics/UserSchematicList.tsx
@@ -17,7 +17,7 @@ import { useLoggedUser } from '@/api/context/loggedUser/loggedUserContext.tsx';
 import { useThemeStore } from '@/api/stores/themeStore.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import MinecraftIcon from '@/components/utility/MinecraftIcon.tsx';
-import {Schematic} from "@/types";
+import {Schematic} from "@/schemas/schematic.schema.tsx";
 
 const UserSchematicList = () => {
   const { isDarkMode } = useThemeStore();

--- a/src/components/features/schematics/UserSchematicList.tsx
+++ b/src/components/features/schematics/UserSchematicList.tsx
@@ -17,7 +17,8 @@ import { useLoggedUser } from '@/api/context/loggedUser/loggedUserContext.tsx';
 import { useThemeStore } from '@/api/stores/themeStore.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import MinecraftIcon from '@/components/utility/MinecraftIcon.tsx';
-import {Schematic} from "@/schemas/schematic.schema.tsx";
+import {Schematic} from "@/types";
+
 
 const UserSchematicList = () => {
   const { isDarkMode } = useThemeStore();

--- a/src/components/features/schematics/upload/SchematicUploadForm.tsx
+++ b/src/components/features/schematics/upload/SchematicUploadForm.tsx
@@ -1,7 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import React, { useState } from 'react';
-import { schematicFormSchema, type SchematicFormValues } from '@/schemas/schematic.schema.tsx';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
@@ -10,6 +9,8 @@ import { FormMarkdownEditor } from './form/FormMarkdownEditor';
 import { MultiSelectCheckboxGroup } from './form/MultiSelectCheckboxGroup';
 import { FormInput } from './form/FormInput';
 import { CategorySelectors } from './form/CategorySelectors';
+import {SchematicFormValues} from "@/types";
+import {schematicFormSchema} from "@/schemas/schematic.schema.tsx";
 
 interface SchematicUploadFormProps {
   onSubmit: (data: SchematicFormValues) => Promise<void>;

--- a/src/components/features/schematics/upload/SchematicsUpload.tsx
+++ b/src/components/features/schematics/upload/SchematicsUpload.tsx
@@ -4,11 +4,11 @@ import { storage } from '@/config/appwrite';
 import { useLoggedUser } from '@/api/context/loggedUser/loggedUserContext';
 import SchematicUploadLoadingOverlay from '@/components/loading-overlays/SchematicUploadLoadingOverlay';
 import { SchematicUploadForm } from './SchematicUploadForm';
-import { type SchematicFormValues } from '@/schemas/schematic.schema';
 import { SchematicPreview } from './SchematicUploadPreview';
 import { generateSlug } from '../utils/generateSlug';
 import { useSaveSchematics } from '@/api/endpoints/useSchematics';
 import {createVersion, minecraftVersion} from "@/config/minecraft.ts";
+import {SchematicFormValues} from "@/types";
 
 function SchematicsUpload() {
   const navigate = useNavigate();

--- a/src/components/features/schematics/upload/form/FileUploadField.tsx
+++ b/src/components/features/schematics/upload/form/FileUploadField.tsx
@@ -15,7 +15,8 @@ import {
   FormDescription,
   FormMessage,
 } from '@/components/ui/form';
-import { SchematicFormValues } from '@/schemas/schematic.schema.tsx';
+import {SchematicFormValues} from "@/types";
+
 
 // Explicitly type allowed file fields
 type FileField = 'schematicFile' | 'imageFiles';

--- a/src/components/features/schematics/upload/form/FormInput.tsx
+++ b/src/components/features/schematics/upload/form/FormInput.tsx
@@ -2,7 +2,8 @@
 import { Control } from 'react-hook-form';
 import { FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { SchematicFormValues } from '@/schemas/schematic.schema.tsx';
+import {SchematicFormValues} from "@/types";
+
 
 // Explicitly type allowed input fields
 type InputField = 'title' | 'description';

--- a/src/components/features/schematics/upload/form/FormMarkdownEditor.tsx
+++ b/src/components/features/schematics/upload/form/FormMarkdownEditor.tsx
@@ -2,7 +2,8 @@
 import { Control, Path } from 'react-hook-form';
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
 import MarkdownEditor from '@/components/utility/MarkdownEditor';
-import { SchematicFormValues } from '@/schemas/schematic.schema.tsx';
+import {SchematicFormValues} from "@/types";
+
 
 interface FormMarkdownEditorProps {
   name: Path<SchematicFormValues>;

--- a/src/components/features/schematics/upload/form/MultiSelectCheckboxGroup.tsx
+++ b/src/components/features/schematics/upload/form/MultiSelectCheckboxGroup.tsx
@@ -2,7 +2,7 @@
 import { Control } from 'react-hook-form';
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
 import { Checkbox } from '@/components/ui/checkbox';
-import { SchematicFormValues } from '@/schemas/schematic.schema.tsx';
+import {SchematicFormValues} from "@/types";
 
 // Explicitly type allowed array fields
 type ArrayField = 'gameVersions' | 'createVersions' | 'modloaders';

--- a/src/components/utility/MarkdownEditor.tsx
+++ b/src/components/utility/MarkdownEditor.tsx
@@ -211,7 +211,7 @@ const MarkdownEditor = ({
   return (
     <MDXEditor
         className={`${isDarkMode ? 'dark-theme' : ''} ${className || ''}`}
-        markdown={value}
+        markdown={value || ''}
       onChange={onChange}
       plugins={plugins}
       placeholder={placeholder || 'Write something...'}

--- a/src/components/utility/MarkdownEditor.tsx
+++ b/src/components/utility/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
 // /src/componets/utility/MarkdownEditor.tsx
-
+import {useThemeStore} from "@/api/stores/themeStore.tsx";
 import '@mdxeditor/editor/style.css';
 import {
   MDXEditor,
@@ -35,7 +35,6 @@ import {
   quotePlugin,
   RealmPlugin,
 } from '@mdxeditor/editor';
-
 // Constants
 const DEFAULT_SNIPPET_CONTENT = `
 export default function App() {
@@ -81,7 +80,6 @@ const SANDPACK_CONFIG: SandpackConfig = {
     },
   ],
 };
-
 const CODE_MIRROR_LANGUAGES = {
   js: 'JavaScript',
   javascript: 'JavaScript',
@@ -104,6 +102,7 @@ const createPlugins = (configs: PluginConfig[]) =>
 
 interface MarkdownEditorProps {
   value: string;
+  className?: string;
   onChange: (val: string) => void;
   showCodeBlocks?: boolean;
   showImages?: boolean;
@@ -118,6 +117,7 @@ interface MarkdownEditorProps {
 }
 
 const MarkdownEditor = ({
+  className = '',
   value,
   onChange,
   showCodeBlocks = true,
@@ -207,11 +207,11 @@ const MarkdownEditor = ({
       })
     },
   ]);
-
+  const { isDarkMode } = useThemeStore();
   return (
     <MDXEditor
-      className='mdxEditor flex flex-col gap-[1px]'
-      markdown={value}
+        className={`${isDarkMode ? 'dark-theme' : ''} ${className || ''}`}
+        markdown={value}
       onChange={onChange}
       plugins={plugins}
       placeholder={placeholder || 'Write something...'}

--- a/src/components/utility/blog/BlogTagsDisplay.tsx
+++ b/src/components/utility/blog/BlogTagsDisplay.tsx
@@ -1,6 +1,6 @@
 
 import { useEffect, useState } from 'react';
-import {Tag} from "@/schemas/blog.schema.tsx";
+import {Tag} from "@/types";
 
 interface BlogTagsDisplayProps {
   value?: Tag[];

--- a/src/components/utility/blog/TagSelector.tsx
+++ b/src/components/utility/blog/TagSelector.tsx
@@ -13,6 +13,7 @@ import { HexColorPicker } from 'react-colorful';
 import { Tag } from '@/types';
 import { databases, ID } from '@/config/appwrite.ts';
 import { Models, Query } from 'appwrite';
+import {PlusIcon} from "lucide-react";
 
 const DATABASE_ID = '67b1dc430020b4fb23e3';
 const BLOG_COLLECTION_ID= '67b2326100053d0e304f';
@@ -110,24 +111,24 @@ export default function TagSelector({ value,db, onChange }: TagSelectorProps) {
   return (
     <>
       <div className='flex flex-row gap-4'>
-        <div className='w-1/4'>
+        <div>
           <Select
             onValueChange={(value) => {
               const tag = tags.find((t) => t.value === value);
               if (tag) toggleTagSelection(tag);
             }}
           >
-            <SelectTrigger>
+            <SelectTrigger className={"cursor-pointer"}>
               <SelectValue placeholder='Select tags' />
             </SelectTrigger>
-            <SelectContent className='bg-foreground hover:bg-foreground'>
+            <SelectContent className='bg-surface-1'>
               {tags.map((tag) => (
-                <SelectItem key={tag.id} value={tag.value}>
+                <SelectItem key={tag.id} value={tag.value} className={"cursor-pointer"}>
                   <span className='flex items-center justify-between'>
                     <span className='mr-2' style={{ color: tag.color }}>
                       {tag.value}
                     </span>
-                    <Button variant='ghost' size='sm' onClick={() => deleteTag(tag.id)}>
+                    <Button variant='ghost'  className={"absolute right-0 "} size='sm' onClick={() => deleteTag(tag.id)}>
                       ❌
                     </Button>
                   </span>
@@ -136,8 +137,7 @@ export default function TagSelector({ value,db, onChange }: TagSelectorProps) {
             </SelectContent>
           </Select>
         </div>
-        <div className='w-2/4'></div>
-        <div className='flex w-1/4 flex-row gap-4'>
+        <div className='flex flex-row gap-4'>
           <Input
             value={newTag}
             onChange={(e) => setNewTag(e.target.value)}
@@ -154,8 +154,8 @@ export default function TagSelector({ value,db, onChange }: TagSelectorProps) {
           </Popover>
         </div>
 
-        <Button className='' onClick={createTag}>
-          Add
+        <Button className='cursor-pointer' onClick={createTag}>
+          <PlusIcon/>
         </Button>
       </div>
       <h3>Selected Tags :</h3>

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,5 +1,5 @@
 // Inspired by react-hot-toast library
-import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast.tsx';
 import { ReactNode, useEffect, useState } from 'react';
 
 const TOAST_LIMIT = 1;

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-
 @custom-variant dark (.dark &);
 
 @theme {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,6 @@ import App from './App';
 import './index.css';
 import 'minecraft-textures-library/src/templates/create-textures.css';
 import 'minecraft-textures-library/src/templates/mc-classic-textures.css'
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClient = new QueryClient();
 

--- a/src/schemas/addon.schema.tsx
+++ b/src/schemas/addon.schema.tsx
@@ -191,19 +191,3 @@ export const AddonSchema = z.object({
   minecraft_versions: z.array(z.string()).optional().nullable(),
 });
 
-export type Addon = z.infer<typeof AddonSchema>;
-export type Screenshot = z.infer<typeof ScreenshotSchema>;
-export type Links = z.infer<typeof LinksSchema>;
-export type Category = z.infer<typeof CategorySchema>;
-export type Author = z.infer<typeof AuthorSchema>;
-export type Logo = z.infer<typeof LogoSchema>;
-export type Hash = z.infer<typeof HashSchema>;
-export type SortableGameVersion = z.infer<typeof SortableGameVersionSchema>;
-export type Dependency = z.infer<typeof DependencySchema>;
-export type Module = z.infer<typeof ModuleSchema>;
-export type LatestFilesIndex = z.infer<typeof LatestFilesIndexSchema>;
-export type SocialLink = z.infer<typeof SocialLinkSchema>;
-export type ServerAffiliation = z.infer<typeof ServerAffiliationSchema>;
-export type LatestFile = z.infer<typeof LatestFileSchema>;
-export type CurseForgeAddon = z.infer<typeof CurseForgeAddonSchema>;
-export type ModrinthAddon = z.infer<typeof ModrinthAddonSchema>;

--- a/src/schemas/adminLogs.schema.tsx
+++ b/src/schemas/adminLogs.schema.tsx
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const AdminLogsSchema = z.object({
+    $id: z.string(),
+    type: z.string(),
+    content: z.string(),
+    category: z.string(),
+    user_uuid: z.string(),
+    $createdAt: z.string(),
+    $updatedAt: z.string(),
+})

--- a/src/schemas/blog.schema.tsx
+++ b/src/schemas/blog.schema.tsx
@@ -1,6 +1,14 @@
 // src/schemas/blog.schema.tsx
 import { z } from "zod";
 
+export const SearchBlogProps = z.object({
+  query: z.string(),
+  page: z.number(),
+  tags: z.array(z.string()),
+  id: z.string(),
+});
+
+
 /**
  * Schema for Tag object in Blog
  */
@@ -15,6 +23,8 @@ export const TagSchema = z.object({
  */
 export const BlogSchema = z.object({
   $id: z.string(),
+  $createdAt: z.string(),
+  $updatedAt: z.string(),
   title: z.string().min(5, "Title must be at least 5 characters long"),
   content: z.string().min(20, "Content must be at least 20 characters long"),
   slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be URL-friendly"),
@@ -22,11 +32,9 @@ export const BlogSchema = z.object({
   status: z.enum(["draft", "published", "archived"]),
   links: z.record(z.any()).nullable().optional(),
   tags: z.array(TagSchema).nullable().optional(),
-  blog_tags: z.array(z.string()).nullable().optional(),
   likes: z.number().int().nonnegative(),
   authors_uuid: z.array(z.string()),
   authors: z.array(z.string()),
-  created_at: z.string()
 });
 
 /**
@@ -68,9 +76,24 @@ export const BlogFilterSchema = z.object({
   search: z.string().optional()
 });
 
+export const SearchBlogResultSchema = z.object({
+  data: z.array(BlogSchema),
+  isLoading: z.boolean(),
+  isError: z.boolean(),
+  error: z.instanceof(Error).nullable(),
+  isFetching: z.boolean(),
+  hasNextPage: z.boolean(),
+  hasPreviousPage: z.boolean(),
+  totalHits: z.number().int().nonnegative(),
+  page: z.number().int().positive(),
+
+});
+
 // Export types based on the schemas
 export type Blog = z.infer<typeof BlogSchema>;
 export type Tag = z.infer<typeof TagSchema>;
 export type CreateBlogInput = z.infer<typeof CreateBlogSchema>;
 export type UpdateBlogInput = z.infer<typeof UpdateBlogSchema>;
 export type BlogFilter = z.infer<typeof BlogFilterSchema>;
+export type SearchBlogProps = z.infer<typeof SearchBlogProps>;
+export type SearchBlogResultSchema = z.infer<typeof SearchBlogResultSchema>;

--- a/src/schemas/blog.schema.tsx
+++ b/src/schemas/blog.schema.tsx
@@ -88,12 +88,3 @@ export const SearchBlogResultSchema = z.object({
   page: z.number().int().positive(),
 
 });
-
-// Export types based on the schemas
-export type Blog = z.infer<typeof BlogSchema>;
-export type Tag = z.infer<typeof TagSchema>;
-export type CreateBlogInput = z.infer<typeof CreateBlogSchema>;
-export type UpdateBlogInput = z.infer<typeof UpdateBlogSchema>;
-export type BlogFilter = z.infer<typeof BlogFilterSchema>;
-export type SearchBlogProps = z.infer<typeof SearchBlogProps>;
-export type SearchBlogResultSchema = z.infer<typeof SearchBlogResultSchema>;

--- a/src/schemas/github.schema.tsx
+++ b/src/schemas/github.schema.tsx
@@ -46,10 +46,6 @@ export const GitHubRepoSchema = z.object({
 /**
  * Schema for GitHub API response when fetching contributors
  */
+
 export const GitHubContributorsResponseSchema = z.array(GitHubUserSchema);
 
-// Export types based on the schemas
-export type GitHubUser = z.infer<typeof GitHubUserSchema>;
-export type ContributorStats = z.infer<typeof ContributorStatsSchema>;
-export type GitHubRepo = z.infer<typeof GitHubRepoSchema>;
-export type GitHubContributorsResponse = z.infer<typeof GitHubContributorsResponseSchema>;

--- a/src/schemas/schematic.schema.tsx
+++ b/src/schemas/schematic.schema.tsx
@@ -17,6 +17,17 @@ export const schematicFormSchema = z.object({
   subCategories: z.array(z.string()).optional(),
 });
 
+export const searchSchematicsPropsSchema = z.object({
+  query: z.string().optional(),
+  page: z.number().optional(),
+  category: z.string().optional(),
+  subCategory: z.string().optional(),
+  createVersion: z.string().optional(),
+  version: z.string().optional(),
+  loaders: z.string().optional(),
+  id: z.string().optional(),
+})
+
 // Database schema for stored schematics
 export const schematicSchema = z.object({
   $id: z.string(),
@@ -65,9 +76,3 @@ export const searchSchematicsResultSchema = z.object({
 
 });
 
-// Type exports
-export type SchematicFormValues = z.infer<typeof schematicFormSchema>;
-export type Schematic = z.infer<typeof schematicSchema>;
-export type PartialSchematic = z.infer<typeof partialSchematicSchema>;
-export type CreateSchematic = z.infer<typeof createSchematicSchema>;
-export type SearchSchematicsResult = z.infer<typeof searchSchematicsResultSchema>;

--- a/src/schemas/user.schema.tsx
+++ b/src/schemas/user.schema.tsx
@@ -4,7 +4,7 @@ import { z } from "zod";
 /**
  * Schema for Target object in User
  */
-const TargetSchema = z.object({
+export const TargetSchema = z.object({
   $id: z.string(),
   $createdAt: z.string(),
   $updatedAt: z.string(),
@@ -18,7 +18,7 @@ const TargetSchema = z.object({
 /**
  * Schema for UserPreferences object
  */
-const UserPreferencesSchema = z.object({
+export const UserPreferencesSchema = z.object({
   theme: z.enum(["light", "dark"]),
   language: z.string(),
   notificationsEnabled: z.boolean(),
@@ -76,10 +76,3 @@ export const UpdateUserPreferencesSchema = z.object({
   notificationsEnabled: z.boolean().optional()
 });
 
-// Export types based on the schemas
-export type User = z.infer<typeof UserSchema>;
-export type Target = z.infer<typeof TargetSchema>;
-export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
-export type CreateUserInput = z.infer<typeof CreateUserSchema>;
-export type UpdateUserProfileInput = z.infer<typeof UpdateUserProfileSchema>;
-export type UpdateUserPreferencesInput = z.infer<typeof UpdateUserPreferencesSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,122 +1,114 @@
 // src/types/index.ts
+import { z } from "zod";
 
-// Re-export types from Addon schema
+// ADDONS TYPE
+
 import {
-  Addon,
-  ModrinthAddon,
-  CurseForgeAddon,
-  Screenshot,
-  Links,
-  Category,
-  Author,
-  Logo,
-  Hash,
-  SortableGameVersion,
-  Dependency,
-  Module,
-  LatestFilesIndex,
-  SocialLink,
-  ServerAffiliation,
-  LatestFile,
+  AddonSchema,
+  ScreenshotSchema,
+  LinksSchema,
+  CategorySchema,
+  AuthorSchema,
+  LogoSchema,
+  HashSchema,
+  SortableGameVersionSchema, DependencySchema,
+  ModuleSchema,
+  LatestFilesIndexSchema,
+  SocialLinkSchema, ServerAffiliationSchema, LatestFileSchema, CurseForgeAddonSchema, ModrinthAddonSchema,
 } from '@/schemas/addon.schema';
+export type Addon = z.infer<typeof AddonSchema>;
+export type Screenshot = z.infer<typeof ScreenshotSchema>;
+export type Links = z.infer<typeof LinksSchema>;
+export type Category = z.infer<typeof CategorySchema>;
+export type Author = z.infer<typeof AuthorSchema>;
+export type Logo = z.infer<typeof LogoSchema>;
+export type Hash = z.infer<typeof HashSchema>;
+export type SortableGameVersion = z.infer<typeof SortableGameVersionSchema>;
+export type Dependency = z.infer<typeof DependencySchema>;
+export type Module = z.infer<typeof ModuleSchema>;
+export type LatestFilesIndex = z.infer<typeof LatestFilesIndexSchema>;
+export type SocialLink = z.infer<typeof SocialLinkSchema>;
+export type ServerAffiliation = z.infer<typeof ServerAffiliationSchema>;
+export type LatestFile = z.infer<typeof LatestFileSchema>;
+export type CurseForgeAddon = z.infer<typeof CurseForgeAddonSchema>;
+export type ModrinthAddon = z.infer<typeof ModrinthAddonSchema>;
 
-export type {
-  Addon,
-  Screenshot,
-  Links,
-  Category,
-  Author,
-  Logo,
-  Hash,
-  SortableGameVersion,
-  Dependency,
-  Module,
-  LatestFilesIndex,
-  SocialLink,
-  ServerAffiliation,
-  LatestFile,
-  CurseForgeAddon,
-  ModrinthAddon,
-};
+// BLOGS TYPES
 
-// Re-export types from Schematic schema
 import {
-  SchematicFormValues,
-  PartialSchematic,
-  CreateSchematic,
-  SearchSchematicsResult
-} from '@/schemas/schematic.schema';
-
-export type {
-  SchematicFormValues,
-  PartialSchematic,
-  CreateSchematic,
-  SearchSchematicsResult
-};
-
-// Re-export types from Blog schema
-import {
-  Blog,
-  CreateBlogInput,
-  UpdateBlogInput,
-  BlogFilter,
-  Tag
+  BlogSchema,
+  TagSchema,
+  CreateBlogSchema,
+  UpdateBlogSchema,
+  BlogFilterSchema,
+  SearchBlogProps,
+  SearchBlogResultSchema
 } from '@/schemas/blog.schema';
 
-export type {
-  Blog,
-  CreateBlogInput,
-  UpdateBlogInput,
-  BlogFilter,
-  Tag
-};
+// Export types based on the schemas
+export type Blog = z.infer<typeof BlogSchema>;
+export type Tag = z.infer<typeof TagSchema>;
+export type CreateBlogInput = z.infer<typeof CreateBlogSchema>;
+export type UpdateBlogInput = z.infer<typeof UpdateBlogSchema>;
+export type BlogFilter = z.infer<typeof BlogFilterSchema>;
+export type SearchBlogProps = z.infer<typeof SearchBlogProps>;
+export type SearchBlogResultSchema = z.infer<typeof SearchBlogResultSchema>;
 
-// Re-export types from User schema
+
+// USERS TYPES
+
 import {
-  User,
-  UserPreferences,
-  Target,
-  CreateUserInput,
-  UpdateUserProfileInput,
-  UpdateUserPreferencesInput
+  UserSchema ,
+  TargetSchema ,
+  UserPreferencesSchema ,
+  CreateUserSchema ,
+  UpdateUserProfileSchema ,
+  UpdateUserPreferencesSchema
 } from '@/schemas/user.schema';
 
-export type {
-  User,
-  UserPreferences,
-  Target,
-  CreateUserInput,
-  UpdateUserProfileInput,
-  UpdateUserPreferencesInput
-};
+// Export types based on the schemas
+export type User = z.infer<typeof UserSchema>;
+export type Target = z.infer<typeof TargetSchema>;
+export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;
+export type UpdateUserProfileInput = z.infer<typeof UpdateUserProfileSchema>;
+export type UpdateUserPreferencesInput = z.infer<typeof UpdateUserPreferencesSchema>;
 
-// Re-export GitHub related types
+// SCHEMATICS TYPES
+
 import {
-  GitHubUser,
-  ContributorStats,
-  GitHubRepo,
-  GitHubContributorsResponse
-} from '@/schemas/github.schema';
+  createSchematicSchema,
+  partialSchematicSchema,
+  schematicFormSchema,
+  schematicSchema,
+  searchSchematicsPropsSchema,
+  searchSchematicsResultSchema
+} from "@/schemas/schematic.schema";
 
-export type {
-  GitHubUser,
-  ContributorStats,
-  GitHubRepo,
-  GitHubContributorsResponse
-};
+export type SearchSchematicsProps =  z.infer<typeof searchSchematicsPropsSchema>
+export type SchematicFormValues = z.infer<typeof schematicFormSchema>;
+export type Schematic = z.infer<typeof schematicSchema>;
+export type PartialSchematic = z.infer<typeof partialSchematicSchema>;
+export type CreateSchematic = z.infer<typeof createSchematicSchema>;
+export type SearchSchematicsResult = z.infer<typeof searchSchematicsResultSchema>;
 
 
+// GITHUB TYPES
+
+import {GitHubUserSchema, ContributorStatsSchema, GitHubRepoSchema, GitHubContributorsResponseSchema } from '@/schemas/github.schema';
+
+export type GitHubUser =  z.infer<typeof GitHubUserSchema>
+export type ContributorStats = z.infer<typeof ContributorStatsSchema>
+export type GitHubRepo = z.infer<typeof GitHubRepoSchema>
+export type GitHubContributorsResponse = z.infer<typeof GitHubContributorsResponseSchema>
+
+// ADMIN LOGS TYPES
+
+import { AdminLogsSchema} from "@/schemas/adminLogs.schema.tsx";
+
+export type AdminLogs = z.infer<typeof AdminLogsSchema>;
 
 
-// Admin logs interface
-export interface Admin_logs {
-  id: string;
-  type: string;
-  content: string;
-  category: string;
-  created_at: string;
-  user_uuid: string;
-}
 
 // LoggedUserContext type
 export interface LoggedUserContextType {
@@ -140,14 +132,3 @@ export interface LoggedUserContextType {
   setError: (error: string | null) => void;
 }
 
-// Search interfaces
-export interface SearchSchematicsProps {
-  query?: string;
-  page?: number;
-  category?: string;
-  subCategory?: string;
-  version?: string;
-  createVersion?: string;
-  loaders?: string;
-  id?: string;
-}


### PR DESCRIPTION
Refactor: Import schematic and blog types from schemas

This commit updates the import path for the `Schematic` and `Blog` types. It now imports them from the schema files instead of the old location. This change ensures that the components use the correct type definitions.
Enhance blog editor with dark mode support

This commit updates the MarkdownEditor component to support dark mode and applies it to the AdminBlogEditor. It also includes minor cleanup in main.tsx and index.css.
Enhance blog editor with tag selector and markdown editor

This commit improves the blog editor by:

- Adding a tag selector component for managing blog tags.
- Integrating a markdown editor for content creation.
- Improving the layout and user experience of the editor.
- Fixing a bug where the markdown editor would not load the initial value.
  Implement blog search functionality

Adds a new hook `useSearchBlogs` to search blogs using Meilisearch.
Updates the `BlogSchema` to include `$createdAt` and `$updatedAt` fields.
Removes `created_at` field from `BlogSchema` and related components.
