### PR TITLE
HOT-FiX: SOME TYPES ERROR

### DIFF
--- a/src/api/endpoints/useSearchAddons.tsx
+++ b/src/api/endpoints/useSearchAddons.tsx
@@ -60,7 +60,7 @@ export const useSearchAddons = (
   // Update hasNextPage only when data is available
   useEffect(() => {
     if (data) {
-      const newHasNextPage = (page - 1) * limit + data.hits.length < data.totalHits;
+      const newHasNextPage = (page - 1) * (limit || 16) + data.hits.length < data.totalHits;
       console.log('Updating hasNextPage:', newHasNextPage); // Debugging
       setHasNextPage(newHasNextPage);
     }

--- a/src/api/endpoints/useSearchBlogs.tsx
+++ b/src/api/endpoints/useSearchBlogs.tsx
@@ -1,6 +1,6 @@
 import searchClient from "@/config/meilisearch";
 import { useQuery } from "@tanstack/react-query";
-import {Blog, SearchBlogProps, SearchBlogResultSchema} from "@/types";
+import {Blog, SearchBlogProps, SearchBlogResult,} from "@/types";
 
 
 export const useSearchBlogs = ({
@@ -8,7 +8,7 @@ export const useSearchBlogs = ({
                                         page = 1,
                                         tags = ['All'] ,
                                         id = 'all',
-                                    }: SearchBlogProps): SearchBlogResultSchema => {
+                                    }: SearchBlogProps): SearchBlogResult => {
     if(query === ''){
         query = '*'
     }

--- a/src/schemas/blog.schema.tsx
+++ b/src/schemas/blog.schema.tsx
@@ -68,10 +68,27 @@ export const BlogFilterSchema = z.object({
   author: z.string().optional(),
   search: z.string().optional()
 });
+/**
+ * Schema for search parameters when querying blogs
+ */
+export const SearchBlogPropsSchema = z.object({
+  query: z.string().default(""),
+  page: z.number().int().positive().default(1),
+  tags: z.array(z.string()).default(["All"]),
+  id: z.string().default("all"),
+});
 
-// Export types based on the schemas
-export type Blog = z.infer<typeof BlogSchema>;
-export type Tag = z.infer<typeof TagSchema>;
-export type CreateBlogInput = z.infer<typeof CreateBlogSchema>;
-export type UpdateBlogInput = z.infer<typeof UpdateBlogSchema>;
-export type BlogFilter = z.infer<typeof BlogFilterSchema>;
+/**
+ * Schema for the search result structure
+ */
+export const SearchBlogResultSchema = z.object({
+  data: z.array(BlogSchema),
+  hasNextPage: z.boolean(),
+  hasPreviousPage: z.boolean(),
+  totalHits: z.number().int().nonnegative(),
+  page: z.number().int().positive(),
+  isLoading: z.boolean(),
+  isError: z.boolean(),
+  error: z.any().optional(),
+  isFetching: z.boolean(),
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,124 +1,112 @@
 // src/types/index.ts
+import { z } from "zod";
 
-// Re-export types from Addon schema
+// ADDONS TYPE
+
 import {
-  Addon,
-  ModrinthAddon,
-  CurseForgeAddon,
-  Screenshot,
-  Links,
-  Category,
-  Author,
-  Logo,
-  Hash,
-  SortableGameVersion,
-  Dependency,
-  Module,
-  LatestFilesIndex,
-  SocialLink,
-  ServerAffiliation,
-  LatestFile,
+  AddonSchema,
+  ScreenshotSchema,
+  LinksSchema,
+  CategorySchema,
+  AuthorSchema,
+  LogoSchema,
+  HashSchema,
+  SortableGameVersionSchema, DependencySchema,
+  ModuleSchema,
+  LatestFilesIndexSchema,
+  SocialLinkSchema, ServerAffiliationSchema, LatestFileSchema, CurseForgeAddonSchema, ModrinthAddonSchema,
 } from '@/schemas/addon.schema';
+export type Addon = z.infer<typeof AddonSchema>;
+export type Screenshot = z.infer<typeof ScreenshotSchema>;
+export type Links = z.infer<typeof LinksSchema>;
+export type Category = z.infer<typeof CategorySchema>;
+export type Author = z.infer<typeof AuthorSchema>;
+export type Logo = z.infer<typeof LogoSchema>;
+export type Hash = z.infer<typeof HashSchema>;
+export type SortableGameVersion = z.infer<typeof SortableGameVersionSchema>;
+export type Dependency = z.infer<typeof DependencySchema>;
+export type Module = z.infer<typeof ModuleSchema>;
+export type LatestFilesIndex = z.infer<typeof LatestFilesIndexSchema>;
+export type SocialLink = z.infer<typeof SocialLinkSchema>;
+export type ServerAffiliation = z.infer<typeof ServerAffiliationSchema>;
+export type LatestFile = z.infer<typeof LatestFileSchema>;
+export type CurseForgeAddon = z.infer<typeof CurseForgeAddonSchema>;
+export type ModrinthAddon = z.infer<typeof ModrinthAddonSchema>;
 
-export type {
-  Addon,
-  Screenshot,
-  Links,
-  Category,
-  Author,
-  Logo,
-  Hash,
-  SortableGameVersion,
-  Dependency,
-  Module,
-  LatestFilesIndex,
-  SocialLink,
-  ServerAffiliation,
-  LatestFile,
-  CurseForgeAddon,
-  ModrinthAddon,
-};
+// BLOGS TYPES
 
-// Re-export types from Schematic schema
 import {
-  Schematic,
-  SchematicFormValues,
-  PartialSchematic,
-  CreateSchematic,
-  SearchSchematicsResult
-} from '@/schemas/schematic.schema';
-
-export type {
-  Schematic,
-  SchematicFormValues,
-  PartialSchematic,
-  CreateSchematic,
-  SearchSchematicsResult
-};
-
-// Re-export types from Blog schema
-import {
-  Blog,
-  CreateBlogInput,
-  UpdateBlogInput,
-  BlogFilter,
-  Tag
+  BlogSchema,
+  TagSchema,
+  CreateBlogSchema,
+  UpdateBlogSchema,
+  BlogFilterSchema, SearchBlogPropsSchema, SearchBlogResultSchema,
 } from '@/schemas/blog.schema';
 
-export type {
-  Blog,
-  CreateBlogInput,
-  UpdateBlogInput,
-  BlogFilter,
-  Tag
-};
+// Export types based on the schemas
+export type Blog = z.infer<typeof BlogSchema>;
+export type Tag = z.infer<typeof TagSchema>;
+export type CreateBlogInput = z.infer<typeof CreateBlogSchema>;
+export type UpdateBlogInput = z.infer<typeof UpdateBlogSchema>;
+export type BlogFilter = z.infer<typeof BlogFilterSchema>;
+export type SearchBlogProps = z.infer<typeof SearchBlogPropsSchema>;
+export type SearchBlogResult = z.infer<typeof SearchBlogResultSchema>;
 
-// Re-export types from User schema
+
+// USERS TYPES
+
 import {
-  User,
-  UserPreferences,
-  Target,
-  CreateUserInput,
-  UpdateUserProfileInput,
-  UpdateUserPreferencesInput
+  UserSchema ,
+  TargetSchema ,
+  UserPreferencesSchema ,
+  CreateUserSchema ,
+  UpdateUserProfileSchema ,
+  UpdateUserPreferencesSchema
 } from '@/schemas/user.schema';
 
-export type {
-  User,
-  UserPreferences,
-  Target,
-  CreateUserInput,
-  UpdateUserProfileInput,
-  UpdateUserPreferencesInput
-};
+// Export types based on the schemas
+export type User = z.infer<typeof UserSchema>;
+export type Target = z.infer<typeof TargetSchema>;
+export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;
+export type UpdateUserProfileInput = z.infer<typeof UpdateUserProfileSchema>;
+export type UpdateUserPreferencesInput = z.infer<typeof UpdateUserPreferencesSchema>;
 
-// Re-export GitHub related types
+// SCHEMATICS TYPES
+
 import {
-  GitHubUser,
-  ContributorStats,
-  GitHubRepo,
-  GitHubContributorsResponse
-} from '@/schemas/github.schema';
+  createSchematicSchema,
+  partialSchematicSchema,
+  schematicFormSchema,
+  schematicSchema,
+  searchSchematicsPropsSchema,
+  searchSchematicsResultSchema
+} from "@/schemas/schematic.schema";
 
-export type {
-  GitHubUser,
-  ContributorStats,
-  GitHubRepo,
-  GitHubContributorsResponse
-};
+export type SearchSchematicsProps =  z.infer<typeof searchSchematicsPropsSchema>
+export type SchematicFormValues = z.infer<typeof schematicFormSchema>;
+export type Schematic = z.infer<typeof schematicSchema>;
+export type PartialSchematic = z.infer<typeof partialSchematicSchema>;
+export type CreateSchematic = z.infer<typeof createSchematicSchema>;
+export type SearchSchematicsResult = z.infer<typeof searchSchematicsResultSchema>;
 
 
+// GITHUB TYPES
+
+import {GitHubUserSchema, ContributorStatsSchema, GitHubRepoSchema, GitHubContributorsResponseSchema } from '@/schemas/github.schema';
+
+export type GitHubUser =  z.infer<typeof GitHubUserSchema>
+export type ContributorStats = z.infer<typeof ContributorStatsSchema>
+export type GitHubRepo = z.infer<typeof GitHubRepoSchema>
+export type GitHubContributorsResponse = z.infer<typeof GitHubContributorsResponseSchema>
+
+// ADMIN LOGS TYPES
+
+import { AdminLogsSchema} from "@/schemas/adminLogs.schema.tsx";
+
+export type AdminLogs = z.infer<typeof AdminLogsSchema>;
 
 
-// Admin logs interface
-export interface Admin_logs {
-  id: string;
-  type: string;
-  content: string;
-  category: string;
-  created_at: string;
-  user_uuid: string;
-}
 
 // LoggedUserContext type
 export interface LoggedUserContextType {
@@ -142,14 +130,3 @@ export interface LoggedUserContextType {
   setError: (error: string | null) => void;
 }
 
-// Search interfaces
-export interface SearchSchematicsProps {
-  query?: string;
-  page?: number;
-  category?: string;
-  subCategory?: string;
-  version?: string;
-  createVersion?: string;
-  loaders?: string;
-  id?: string;
-}


### PR DESCRIPTION
Key changes:

- Replaces manual type definitions with types inferred from Zod schemas.
- Imports Zod schemas from relevant schema files (e.g., `addon.schema.ts`, `blog.schema.ts`).
- Exports types using `z.infer<typeof SchemaName>`.
- Updates `useSearchBlogs` to use the new `SearchBlogResult` type.
- Updates `useSearchAddons` to use the new `limit` type.