### PR TITLE
Add @react/simple-icons for brand icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@hookform/resolvers": "^4.1.2",
+        "@icons-pack/react-simple-icons": "^12.1.0",
         "@mdxeditor/editor": "^3.21.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-avatar": "^1.1.3",
@@ -1108,6 +1109,15 @@
       "version": "2.0.3",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-12.1.0.tgz",
+      "integrity": "sha512-4pj96IXQJ0FpUKouzdC5mnie6bdy5/8fPk8GIGFp6/sPUVF9WcKarQgUCFzT2vb8zkWHudjTHLdjtDoztmNNhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.2",
+    "@icons-pack/react-simple-icons": "^12.1.0",
     "@mdxeditor/editor": "^3.21.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",

--- a/src/components/features/addons/addon-details/AddonDetailsContent.tsx
+++ b/src/components/features/addons/addon-details/AddonDetailsContent.tsx
@@ -6,7 +6,8 @@ import { ExternalLinks } from '@/components/features/addons/addon-card/ExternalL
 import { CardContent } from '@/components/ui/card.tsx';
 import { ReactNode, useEffect, useState } from 'react';
 import { CurseForgeAddon, ModrinthAddon } from '@/types';
-import { Bug, Github, Globe } from 'lucide-react';
+import { Bug, Globe } from 'lucide-react';
+import { SiGithub } from '@icons-pack/react-simple-icons';
 
 export interface AddonDetailsParams {
   versions: string[];
@@ -31,7 +32,7 @@ export const AddonDetailsContent = ({
   const { sourceUrl, issuesUrl, websiteUrl } = curseforge_raw?.links || {};
 
   const externalLinks = [
-    createLink(<Github className='h-4 w-4' />, 'Source Code', sourceUrl || ''),
+    createLink(<SiGithub className='h-4 w-4' />, 'Source Code', sourceUrl || ''),
     createLink(<Bug className='h-4 w-4' />, 'Issue Tracker', issuesUrl || ''),
     createLink(<Globe className='h-4 w-4' />, 'Website', websiteUrl),
   ].filter((link): link is { icon: ReactNode; label: string; url: string } => link !== null);
@@ -48,8 +49,6 @@ export const AddonDetailsContent = ({
     setAvailableOn(platforms);
   }, [curseforge_raw, modrinth_raw]);
 
-  console.log(availableOn);
-  console.log(availableOn.includes('modrinth'));
   return (
     <CardContent className='space-y-6'>
       <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>


### PR DESCRIPTION
Since lucide-react is deprecating their brand icons, I'd added simple-icons to replace that.